### PR TITLE
Fixes of a few bugs on Windows

### DIFF
--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -137,7 +137,7 @@ impl<'a> Frontend<'a> {
                     match event {
                         Some(Ok(event)) => {
                             if let crossterm::event::Event::Key(k) = event {
-                                self.torrent_list.keybindings(k.code, &mut self.terminal).await;
+                                self.torrent_list.keybindings(k, &mut self.terminal).await;
                             }
                         }
                         _ => break

--- a/src/frontend/torrent_list.rs
+++ b/src/frontend/torrent_list.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 use hashbrown::HashMap;
 use ratatui::{
     layout::Constraint,
@@ -62,14 +62,10 @@ impl<'a> TorrentList<'a> {
         }
     }
 
-    pub async fn keybindings<T: Backend>(&mut self, k: KeyCode, terminal: &mut Terminal<T>) {
+    pub async fn keybindings<T: Backend>(&mut self, k_event: KeyEvent, terminal: &mut Terminal<T>) {
+        let k = k_event.code;
         match k {
-            KeyCode::Char('q') | KeyCode::Esc => {
-                self.reset_cursor();
-                self.input.clear();
-                self.quit(terminal).await;
-            }
-            k if self.show_popup => match k {
+            k if self.show_popup && k_event.kind == KeyEventKind::Press => match k {
                 KeyCode::Enter => self.submit_magnet_link(terminal).await,
                 KeyCode::Char(to_insert) => {
                     self.enter_char(to_insert);
@@ -94,6 +90,11 @@ impl<'a> TorrentList<'a> {
                 }
                 _ => {}
             },
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.reset_cursor();
+                self.input.clear();
+                self.quit(terminal).await;
+            }
             k => match k {
                 KeyCode::Down | KeyCode::Char('j') => {
                     self.next();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 
 use clap::Parser;
 use directories::{ProjectDirs, UserDirs};
-use tokio::{fs::create_dir, io::AsyncReadExt, runtime::Runtime, spawn, sync::mpsc};
+use tokio::{fs::create_dir_all, io::AsyncReadExt, runtime::Runtime, spawn, sync::mpsc};
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use vincenzo::{
     cli::Args,
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Error> {
     let mut config_path = dotfile.config_dir().to_path_buf();
 
     if !config_path.exists() {
-        create_dir(&config_path).await.unwrap();
+        create_dir_all(&config_path).await.unwrap();
     }
 
     config_path.push("config.toml");


### PR DESCRIPTION
This PR fixes the following:
- The config folder not being created recursively, causing an error (not specific to Windows, but fixed)
- Windows seems to treat key events differently on the terminal, so it ended up duplicating most key presses (fixed)

That's it thanks!