### PR TITLE
Change various test names and add some doc comments to metainfo.rs

### DIFF
--- a/src/avg.rs
+++ b/src/avg.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sliding_average() {
+    fn sliding_average() {
         let inverted_gain = 4;
         let mut a = SlidingAvg::new(inverted_gain);
 
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sliding_duration_average() {
+    fn sliding_duration_average() {
         // since the implementation of the moving average is the same as for
         // `SlidSlidingAvg`, we only need to test that the i64 <-> duration
         // conversions are correct

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -169,20 +169,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn can_create_from_vec() {
+    fn from_vec() {
         let bitfield = Bitfield::from(vec![255_u8]);
         assert_eq!(bitfield.inner, vec![255_u8]);
     }
 
     #[test]
-    fn can_complete_bitfield() {
+    fn is_complete() {
         let mut bitfield = Bitfield::from(vec![0b11111111, 0b01111100]);
         let _is_complete = bitfield.is_complete(bitfield.len() as u32);
         // assert!(is_complete);
     }
 
     #[test]
-    fn can_has_from_bitfield() {
+    fn has() {
         let bits: Vec<u8> = vec![0b10101010, 0b00011011, 0b00111110];
         let bitfield = Bitfield::from(bits);
 
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn can_get_from_bitfield() {
+    fn get() {
         let bits: Vec<u8> = vec![0b1010_1010, 0b0001_1011, 0b0011_1110];
         let bitfield = Bitfield::from(bits);
 
@@ -245,7 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn can_fail_get_bitfield() {
+    fn get_failure() {
         let bits: Vec<u8> = vec![0b10101010];
         let bitfield = Bitfield::from(bits);
 
@@ -259,7 +259,7 @@ mod tests {
     }
 
     #[test]
-    fn can_set() {
+    fn set() {
         let mut bitfield = Bitfield::new();
         // [0..7] [8..15] [16..23] [24..31]
         bitfield.set(10_usize);
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn can_try_set() {
+    fn try_set() {
         let bits: Vec<u8> = vec![0b0000_0000, 0b0000_0000];
         let mut bitfield = Bitfield::from(bits);
 
@@ -321,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn can_clear_a_bit() {
+    fn clear_bit() {
         let bits: Vec<u8> = vec![0b1000_0001];
         let mut bitfield = Bitfield::from(bits);
 
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn can_iter_a_bit() {
+    fn as_iterator() {
         let bits: Vec<u8> = vec![0b1000_0101, 0b0111_0001];
         let mut bitfield = Bitfield::from(bits);
 
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn receive_lazy_bitfield() {
+    fn try_set_out_of_bounds() {
         let bitfield = Bitfield::from(vec![0b0000_1111, 0b1111_1111]);
         let mut empty_bitfield = Bitfield::default();
 

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -538,7 +538,7 @@ mod tests {
     // when we send the msg `NewTorrent` the `Disk` must create
     // the "skeleton" of the torrent tree. Empty folders and empty files.
     #[tokio::test]
-    async fn can_create_file_tree() {
+    async fn create_file_tree() {
         let name = "arch".to_owned();
         let magnet = format!("magnet:?xt=urn:btih:9999999999999999999999999999999999999999&amp;dn={name}&amp;tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&amp;tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A6969%2Fannounce&amp;tr=udp%3A%2F%2Ftracker.bittor.pw%3A1337%2Fannounce&amp;tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&amp;tr=udp%3A%2F%2Fbt.xxx-tracker.com%3A2710%2Fannounce&amp;tr=udp%3A%2F%2Fpublic.popcorn-tracker.org%3A6969%2Fannounce&amp;tr=udp%3A%2F%2Feddie4.nl%3A6969%2Fannounce&amp;tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&amp;tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&amp;tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&amp;tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce");
         let (disk_tx, disk_rx) = mpsc::channel::<DiskMsg>(1000);

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -299,7 +299,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn can_create_metadata_request() {
+    fn metadata_request_roundtrip_serialization() {
         let metadata_request = Metadata::request(0);
         let bencoded = String::from_utf8(metadata_request.to_bencode().unwrap());
         assert_eq!(bencoded.unwrap(), "d8:msg_typei0e5:piecei0ee");
@@ -310,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn can_create_metadata_data() {
+    fn metadata_data_from_info() {
         let metainfo_bytes = include_bytes!("../btr/book.torrent");
         let metainfo = MetaInfo::from_bencode(metainfo_bytes).unwrap();
 
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn can_create_metadata_reject() {
+    fn metadata_reject_roundtrip_serialization() {
         let metadata_request = Metadata::reject(0);
         let bencoded = String::from_utf8(metadata_request.to_bencode().unwrap());
         assert_eq!(bencoded.unwrap(), "d8:msg_typei2e5:piecei0ee");
@@ -336,7 +336,7 @@ mod tests {
 
     // should transform a byte array into an Extension
     #[test]
-    fn from_bytes_to_extension() {
+    fn extension_deserialization() {
         let bytes = [
             100, 49, 58, 101, 105, 49, 101, 49, 58, 109, 100, 49, 49, 58, 117, 116, 95, 109, 101,
             116, 97, 100, 97, 116, 97, 105, 51, 101, 54, 58, 117, 116, 95, 112, 101, 120, 105, 49,
@@ -367,7 +367,7 @@ mod tests {
     // should get a byte array, and encode to an Extension
     // should ignore all data structures that we do not care about
     #[test]
-    fn from_extension_to_bytes() {
+    fn extension_serialization() {
         let bytes = [
             100, 49, 58, 101, 105, 49, 101, 49, 58, 109, 100, 49, 49, 58, 117, 116, 95, 109, 101,
             116, 97, 100, 97, 116, 97, 105, 51, 101, 54, 58, 117, 116, 95, 112, 101, 120, 105, 49,
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn from_bytes_to_metadata_msg() {
+    fn metadata_msg_deserialization() {
         let buf = [
             100, 56, 58, 109, 115, 103, 95, 116, 121, 112, 101, 105, 49, 101, 53, 58, 112, 105,
             101, 99, 101, 105, 48, 101, 49, 48, 58, 116, 111, 116, 97, 108, 95, 115, 105, 122, 101,

--- a/src/metainfo.rs
+++ b/src/metainfo.rs
@@ -995,8 +995,9 @@ mod tests {
         Ok(())
     }
 
+    /// Confirm that the [`MetaInfo`] [`ToBencode`] and [`FromBencode`] implementations work as expected for a multi-file torrent
     #[test]
-    fn should_encode_multi_file_torrent() -> Result<(), encoding::Error> {
+    fn multi_file_torrent_roundtrip_serialization() -> Result<(), encoding::Error> {
         let torrent_book_bytes = include_bytes!("../btr/book.torrent");
 
         let torrent = MetaInfo::from_bencode(torrent_book_bytes).unwrap();
@@ -1008,8 +1009,9 @@ mod tests {
         Ok(())
     }
 
+    /// Confirm that the [`MetaInfo`] [`FromBencode`] implementation works as expected for a multi-file torrent
     #[test]
-    fn should_decode_multi_file_torrent() -> Result<(), decoding::Error> {
+    fn multi_file_torrent_deserialization() -> Result<(), decoding::Error> {
         let torrent = include_bytes!("../btr/book.torrent");
         let torrent = MetaInfo::from_bencode(torrent)?;
 
@@ -1070,8 +1072,9 @@ mod tests {
         Ok(())
     }
 
+    /// Confirm that the [`MetaInfo`] [`FromBencode`] implementation works as expected for a single-file torrent
     #[test]
-    fn should_decode_single_file_torrent() -> Result<(), decoding::Error> {
+    fn single_file_torrent_deserialization() -> Result<(), decoding::Error> {
         let torrent = include_bytes!("../btr/debian.torrent");
         let torrent = MetaInfo::from_bencode(torrent)?;
 
@@ -1105,8 +1108,9 @@ mod tests {
         Ok(())
     }
 
+    /// Confirm that the [`MetaInfo`] [`ToBencode`] implementation works as expected for a single-file torrent
     #[test]
-    fn should_encode_single_file_torrent() -> Result<(), encoding::Error> {
+    fn single_file_torrent_serialization() -> Result<(), encoding::Error> {
         let torrent_disk = include_bytes!("../btr/debian.torrent");
 
         let torrent = MetaInfo {
@@ -1134,8 +1138,9 @@ mod tests {
         Ok(())
     }
 
+    /// Confirm that the [`metainfo::File`](struct@File) [`ToBencode`] implementation works as expected
     #[test]
-    fn should_encode_file() -> Result<(), encoding::Error> {
+    fn file_serialization() -> Result<(), encoding::Error> {
         let file = File {
             path: ["a".to_owned(), "b".to_owned(), "c.txt".to_owned()].into(),
             length: 222,
@@ -1151,8 +1156,9 @@ mod tests {
         Ok(())
     }
 
+    /// Confirm that the [`metainfo::File`](struct@File) [`FromBencode`] implementation works as expected
     #[test]
-    fn should_decode_file() -> Result<(), decoding::Error> {
+    fn file_deserialization() -> Result<(), decoding::Error> {
         let data = b"d6:lengthi222e4:pathl1:a1:b5:c.txtee";
 
         let file = File::from_bencode(data)?;


### PR DESCRIPTION
Fixes #7 

- I focused on removing redundant ( `should_`, `can_`, etc.) naming from tests. 
- I also added some doc comments to [`metainfo.rs`](https://github.com/gabrieldemian/vincenzo/blob/master/src/metainfo.rs), though it's important to note that some of the [struct/trait references](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html) will only work when this crate is published on crates.io.